### PR TITLE
Improved support for nullable types (Map.cs, IMap.cs, ResultFieldDeta…

### DIFF
--- a/QueryFirst/IMap.cs
+++ b/QueryFirst/IMap.cs
@@ -11,6 +11,6 @@
         /// </summary>
         /// <param name="p">The Transact SQL type name.</param>
         /// <returns>The C# type name.</returns>
-        string DBType2CSType(string p);
+        string DBType2CSType(string p, bool nullable=true);
     }
 }

--- a/QueryFirst/Map.cs
+++ b/QueryFirst/Map.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,33 +9,41 @@ namespace QueryFirst
 {
     class Map : IMap
     {
-        public string DBType2CSType(string p)
+        public string DBType2CSType(string p, bool nullable=true)
         {
             switch (p.ToLower())
             {
                 case "bigint":
-                    return "long";
+                    return nullable ? "long?" : "long";
                 case "binary":
+                case "image":
+                case "timestamp":
+                case "varbinary":
                     return "byte[]";
                 case "bit":
-                    return "bool";
+                    return nullable ? "bool?" : "bool";
                 case "date":
                 case "datetime":
                 case "datetime2":
-                    return "DateTime";
+                case "smalldatetime":
+                case "time":
+                    return nullable ? "DateTime?" : "DateTime";
                 case "datetimeoffset":
-                    return "DateTimeOffset";
+                    return nullable ? "DateTimeOffset?" : "DateTimeOffset";
                 case "decimal":
                 case "money":
-                    return "decimal";
+                case "smallmoney":
+                    return nullable ? "decimal?" : "decimal";
                 case "float":
-                    return "double";
-                case "image":
-                case "timestamp":
-                    return "byte[]";
+                    return nullable ? "double?" : "double";
+                case "real":
+                    return nullable ? "float?" : "float";
                 case "smallint":
+                    return nullable ? "short?" : "short";
+                case "tinyint":
+                    return nullable ? "byte?" : "byte";
                 case "int":
-                    return "int";
+                    return nullable ? "int?" : "int";
                 case "char":
                 case "nchar":
                 case "ntext":
@@ -44,7 +53,11 @@ namespace QueryFirst
                 case "xml":
                     return "string";
                 case "sql_variant":
-                    return "Object";
+                case "variant":
+                case "udt":
+                    return "object";
+                case "structured":
+                    return "DataTable";
                 default:
                     throw new Exception("type not matched : " + p);
                     // todo : keep going here. old method had a second switch on ResultFieldDetails.DataType to catch a bunch of never seen types

--- a/QueryFirst/Query.cs
+++ b/QueryFirst/Query.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -57,7 +58,7 @@ namespace QueryFirst
         public string Text { get { return text; } }
         public bool IsQFQuery()
         {
-            return true;
+            return Text.Contains("managed by QueryFirst");
         }
         public void ConvertForDesignDebug()
         {

--- a/QueryFirst/ResultFieldDetails.cs
+++ b/QueryFirst/ResultFieldDetails.cs
@@ -39,7 +39,7 @@ namespace QueryFirst
         {
             get
             {
-                return TinyIoCContainer.Current.Resolve<IMap>().DBType2CSType(DataTypeName);
+                return TinyIoCContainer.Current.Resolve<IMap>().DBType2CSType(DataTypeName, AllowDBNull);
             }
         }
         public string CSColumnName

--- a/QueryFirst/TinyIoC.cs
+++ b/QueryFirst/TinyIoC.cs
@@ -3281,9 +3281,13 @@ namespace TinyIoC
 			{
 				var types = assemblies.SelectMany(a => a.SafeGetTypes()).Where(t => !IsIgnoredType(t, registrationPredicate)).ToList();
 
-				var concreteTypes = types
-					.Where(type => type.IsClass() && (type.IsAbstract() == false) && (type != this.GetType() && (type.DeclaringType != this.GetType()) && (!type.IsGenericTypeDefinition())))
-					.ToList();
+                    var concreteTypes = types.Where(
+                        type => type.IsClass()
+                        && (type.IsAbstract() == false)
+                        && (!type.IsGenericParameter() || type.DeclaringType != this.GetType())
+                        && type != this.GetType()
+                        && !type.IsGenericTypeDefinition()
+                        ).ToList();
 
 				foreach (var type in concreteTypes)
 				{
@@ -3302,7 +3306,9 @@ namespace TinyIoC
 				}
 
 				var abstractInterfaceTypes = from type in types
-											 where ((type.IsInterface() || type.IsAbstract()) && (type.DeclaringType != this.GetType()) && (!type.IsGenericTypeDefinition()))
+											 where ((type.IsInterface() || type.IsAbstract()) 
+                                                && (!type.IsGenericParameter() || type.DeclaringType != this.GetType()) 
+                                                && (!type.IsGenericTypeDefinition()))
 											 select type;
 
 				foreach (var type in abstractInterfaceTypes)

--- a/QueryFirst/WrapperClassMaker.cs
+++ b/QueryFirst/WrapperClassMaker.cs
@@ -170,8 +170,8 @@ using System.Linq;";
             int j = 0;
             foreach (var col in ctx.QueryFields)
             {
-                code.AppendLine("if(! (record[" + j + "] == null) && !( record[" + j + "] == DBNull.Value ))");
-                code.AppendLine("returnVal." + col.ColumnName + " =  (" + col.DataType + ")record[" + j++ + "];");
+                code.AppendLine("if(record[" + j + "] != null && record[" + j + "] != DBNull.Value)");
+                code.AppendLine("returnVal." + col.ColumnName + " =  (" + col.CSType + ")record[" + j++ + "];");
             }
             // call OnLoad method in user's half of partial class
             code.AppendLine("returnVal.OnLoad();");


### PR DESCRIPTION
…ils.cs, WrapperClassMaker.cs)

Extended mapping of SQL types to C# types (Map.cs)
Disable QueryFirst functionality when saving non-QuryFirst .sql files (Query.cs)
Reset comments to debug mode when switching from Release to Debug builds (Root.cs)
Performance fix: Don't use TinyIoC.AutoRegister(), becuase it registers thousands of types and we are only using four. (Root.cs)
Fix for TinyIoC.cs bug: type.DeclaringType throws an exception if type.IsGenericParameter is false (TinyIoC.cs) - I should probably also submit a pull request to the TiynIoC repo for this.

QueryFirst is now working well for me with these changes, and is a lot quicker on startup.
