### PR TITLE
Revised regex parsing to allow for Tabs and ignore extra whitespace

### DIFF
--- a/QueryFirst/Providers/SqlClient.cs
+++ b/QueryFirst/Providers/SqlClient.cs
@@ -25,11 +25,11 @@ namespace QueryFirst.Providers
             // get design time section
             var dt = Regex.Match(queryText, "-- designTime(?<designTime>.*)-- endDesignTime", RegexOptions.Singleline).Value;
             // extract declared parameters
-            string pattern = "declare[^;]*";
+            string pattern = "declare[^;\n]*";
             Match m = Regex.Match(dt, pattern, RegexOptions.IgnoreCase);
             while (m.Success)
             {
-                string[] parts = m.Value.Split(' ');
+                string[] parts = m.Value.Split(new[] { ' ', '	' }, StringSplitOptions.RemoveEmptyEntries);
                 var qp = TinyIoC.TinyIoCContainer.Current.Resolve<IQueryParamInfo>();
                 FillParamInfo(qp, parts[1].Substring(1), parts[2]);
                 queryParams.Add(qp);


### PR DESCRIPTION
- Allow line endings for declarations without semi-colons
- Allow the use of tabs in addition to spaces for declared parameters
- Ignore extra spaces or tabs in the declaration lines