### PR TITLE
SmartFormat the code in the query's "Results.cs" file + Allow the word "Results" in the file name

### DIFF
--- a/QueryFirstQueryTemplate/QueryResults.cs
+++ b/QueryFirstQueryTemplate/QueryResults.cs
@@ -3,7 +3,7 @@
 namespace $rootnamespace$
 {
 	[Serializable]
-	public partial class $safeitemname$¤
+	public partial class $safeitemname$
 	{
 		// Partial class extends the generated results class
 		// Serializable by default, but you can change this here		
@@ -18,11 +18,11 @@ namespace $rootnamespace$
 	// POCO factory, called for each line of results. For polymorphic POCOs, put your instantiation logic here.
 	// Tag the results class as abstract above, add some virtual methods, create some subclasses, then instantiate them here based on data in the row.
 	// This name follows the root name of the query. You can change it by renaming the parent .sql file.
-	public partial class $safeitemname$
+	public partial class $safeitemname$¤
 	{
-		$safeitemname$¤ CreatePoco(System.Data.IDataRecord record)
+		$safeitemname$ CreatePoco(System.Data.IDataRecord record)
 		{
-			return new $safeitemname$¤();
+			return new $safeitemname$();
 		}
 	}
 }


### PR DESCRIPTION
- Tidies the code generated in the query's Results.cs file
- Allows the word "Results" in the query file name, e.g. BarResultsQuery1.sql